### PR TITLE
Some code style improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ echo "create table hello_world as select i::int4 from generate_series(1, (10^6):
 # (seqscan is expected, total time ~150ms, depending on resources)
 nancy run \
   --run-on localhost \
-  --db-dump-path file://$(pwd)/sample.dump.bz2 \
+  --db-dump file://$(pwd)/sample.dump.bz2 \
   --tmp-path /tmp \
   --workload-custom-sql "select count(1) from hello_world where i between 100000 and 100010;"
 
@@ -115,7 +115,7 @@ nancy run \
 # (expected total time: ~0.05ms)
 nancy run \
   --run-on localhost \
-  --db-dump-path file://$(pwd)/sample.dump.bz2 \
+  --db-dump file://$(pwd)/sample.dump.bz2 \
   --tmp-path /tmp \
   --workload-custom-sql "select count(1) from hello_world where i between 100000 and 100010;" \
   --target-ddl-do "create index i_hello_world_i on hello_world(i);" \
@@ -128,7 +128,7 @@ nancy run \
   --run-on aws \
   --aws-ec2-type "i3.large" \
   --aws-keypair-name awskey --aws-ssh-key-path file://$(echo ~)/.ssh/awskey.pem  \
-  --db-dump-path "create table a as select i::int4 from generate_series(1, (10^9)::int) _(i);" \
+  --db-dump "create table a as select i::int4 from generate_series(1, (10^9)::int) _(i);" \
   --workload-custom-sql "select count(1) from a where i between 10 and 20;"
 ```
 

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -1009,7 +1009,7 @@ echo -e "  Report: $ARTIFACTS_DESTINATION/$ARTIFACTS_FILENAME.json"
 echo -e "  Query log: $ARTIFACTS_DESTINATION/$ARTIFACTS_FILENAME.log.gz"
 echo -e "  -------------------------------------------"
 echo -e "  Workload summary:"
-echo -e "    Sumarized query duration:\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.queries_duration') " ms"
+echo -e "    Summarized query duration:\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.queries_duration') " ms"
 echo -e "    Queries:\t\t\t" $( docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.queries_number')
 echo -e "    Query groups:\t\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.normalyzed_info| length')
 echo -e "    Errors:\t\t\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.errors_number')

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -367,10 +367,16 @@ function checkParams() {
   [ ! -z ${WORKLOAD_REAL+x} ] && let workloads_count=$workloads_count+1
   [ ! -z ${WORKLOAD_CUSTOM_SQL+x} ] && let workloads_count=$workloads_count+1
 
+  #--db-prepared-snapshot or --db-dump
+  if ([ -z ${DB_PREPARED_SNAPSHOT+x} ]  &&  [ -z ${DB_DUMP_PATH+x} ]); then
+    >&2 echo "ERROR: The object (database) is not defined."
+    exit 1;
+  fi
+
   # --workload-real or --workload-basis-path or --workload-custom-sql
   if [ "$workloads_count" -eq "0" ]
   then
-    >&2 echo "ERROR: Workload not given."
+    >&2 echo "ERROR: The workload is not defined."
     exit 1;
   fi
 
@@ -378,12 +384,6 @@ function checkParams() {
   then
     >&2 echo "ERROR: 2 or more workload sources are given."
     exit 1
-  fi
-
-  #--db-prepared-snapshot or --db-dump
-  if ([ -z ${DB_PREPARED_SNAPSHOT+x} ]  &&  [ -z ${DB_DUMP_PATH+x} ]); then
-    >&2 echo "ERROR: Snapshot or dump not given."
-    exit 1;
   fi
 
   if ([ ! -z ${DB_PREPARED_SNAPSHOT+x} ]  &&  [ ! -z ${DB_DUMP_PATH+x} ])

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -90,7 +90,7 @@ while true; do
 
   Reserved / Not yet implemented.
 
-  \033[1m--db-dump-path\033[22m (string)
+  \033[1m--db-dump\033[22m (string)
 
   Specify the path to database dump (created by pg_dump) to be used as an input.
 
@@ -193,7 +193,7 @@ while true; do
     --db-prepared-snapshot )
       #Still unsupported
       DB_PREPARED_SNAPSHOT="$2"; shift 2 ;;
-    --db-dump-path )
+    --db-dump )
       DB_DUMP_PATH="$2"; shift 2 ;;
     --after-db-init-code )
       #s3 url|filename|content
@@ -380,7 +380,7 @@ function checkParams() {
     exit 1
   fi
 
-  #--db-prepared-snapshot or --db-dump-path
+  #--db-prepared-snapshot or --db-dump
   if ([ -z ${DB_PREPARED_SNAPSHOT+x} ]  &&  [ -z ${DB_DUMP_PATH+x} ]); then
     >&2 echo "ERROR: Snapshot or dump not given."
     exit 1;
@@ -398,7 +398,7 @@ function checkParams() {
       echo "$DB_DUMP_PATH" > $TMP_PATH/db_dump_tmp.sql
       DB_DUMP_PATH="$TMP_PATH/db_dump_tmp.sql"
     else
-      [ "$DEBUG" -eq "1" ] && echo "DEBUG: Value given as db-dump-path will use as filename"
+      [ "$DEBUG" -eq "1" ] && echo "DEBUG: Value given as db-dump will use as filename"
     fi
     DB_DUMP_FILENAME=$(basename $DB_DUMP_PATH)
     DB_DUMP_EXT=${DB_DUMP_FILENAME##*.}

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -1008,9 +1008,9 @@ echo -e "$(date "+%Y-%m-%d %H:%M:%S"): Run done for $DURATION"
 echo -e "  Report: $ARTIFACTS_DESTINATION/$ARTIFACTS_FILENAME.json"
 echo -e "  Query log: $ARTIFACTS_DESTINATION/$ARTIFACTS_FILENAME.log.gz"
 echo -e "  -------------------------------------------"
-echo -e "  Summary:"
-echo -e "    Queries duration:\t\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.queries_duration') " ms"
-echo -e "    Queries count:\t\t" $( docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.queries_number')
-echo -e "    Normalized queries count:\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.normalyzed_info| length')
-echo -e "    Errors count:\t\t\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.errors_number')
+echo -e "  Workload summary:"
+echo -e "    Sumarized query duration:\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.queries_duration') " ms"
+echo -e "    Queries:\t\t\t" $( docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.queries_number')
+echo -e "    Query groups:\t\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.normalyzed_info| length')
+echo -e "    Errors:\t\t\t" $(docker_exec cat /$MACHINE_HOME/$ARTIFACTS_FILENAME.json | jq '.overall_stat.errors_number')
 echo -e "-------------------------------------------"

--- a/tests/nancy_run_before_init_code.sh
+++ b/tests/nancy_run_before_init_code.sh
@@ -3,7 +3,7 @@
 output=$(${BASH_SOURCE%/*}/../nancy run \
   --before-db-init-code "select abs from beforeinittable;" \
   --workload-custom-sql "file://$srcDir/custom.sql" \
-  --db-dump-path "file://$srcDir/test.dump.bz2" \
+  --db-dump "file://$srcDir/test.dump.bz2" \
   --tmp-path $srcDir/tmp \
   2>&1)
 

--- a/tests/nancy_run_ebs_disk_size_warning.sh
+++ b/tests/nancy_run_ebs_disk_size_warning.sh
@@ -3,7 +3,7 @@
 output=$(${BASH_SOURCE%/*}/../nancy run \
   --ebs-volume-size sa \
   --workload-custom-sql "file://$srcDir/custom.sql" \
-  --db-dump-path "file://$srcDir/test.dump.bz2" \
+  --db-dump "file://$srcDir/test.dump.bz2" \
   --tmp-path $srcDir/tmp \
   2>&1)
 

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -10,7 +10,7 @@ nancyRun="$parentDir/nancy_run.sh"
 
 output=$(
   $nancyRun --workload-real "file://$srcDir/sample.replay" \
-    --db-dump-path "file://$srcDir/test.dump.bz2" \
+    --db-dump "file://$srcDir/test.dump.bz2" \
     --tmp-path $srcDir/tmp 2>&1
 )
 

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -15,7 +15,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Queries:           1" ]]; then
+if [[ $output =~ "Queries:[[:space:]]+1" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -14,7 +14,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Queries duration:" ]]; then
+if [[ $output =~ "Sumarized query duration:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -22,4 +22,3 @@ else
   >&2 echo -e "Output: $output"
   exit 1
 fi
-

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -14,7 +14,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Sumarized query duration:" ]]; then
+if [[ $output =~ "Errors:            0:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -9,8 +9,9 @@ fi
 nancyRun="$parentDir/nancy_run.sh"
 
 output=$(
-  $nancyRun --workload-real "file://$srcDir/sample.replay" \
-    --db-dump "file://$srcDir/test.dump.bz2" \
+  $nancyRun \
+    --db-dump "create table hello_world as select i from generate_series(1, 1000)i _(i);" \
+    --workload-real "file://$srcDir/sample.replay" \
     --tmp-path $srcDir/tmp 2>&1
 )
 

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -10,12 +10,12 @@ nancyRun="$parentDir/nancy_run.sh"
 
 output=$(
   $nancyRun \
-    --db-dump "create table hello_world as select i from generate_series(1, 1000) _(i);" \
+    --db-dump "create table hello_world as select i, i as id from generate_series(1, 1000) _(i);" \
     --workload-real "file://$srcDir/sample.replay" \
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Errors:            0:" ]]; then
+if [[ $output =~ "Queries:           1" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -22,3 +22,4 @@ else
   >&2 echo -e "Output: $output"
   exit 1
 fi
+

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -10,7 +10,7 @@ nancyRun="$parentDir/nancy_run.sh"
 
 output=$(
   $nancyRun \
-    --db-dump "create table hello_world as select i from generate_series(1, 1000)i _(i);" \
+    --db-dump "create table hello_world as select i from generate_series(1, 1000) _(i);" \
     --workload-real "file://$srcDir/sample.replay" \
     --tmp-path $srcDir/tmp 2>&1
 )

--- a/tests/nancy_run_localhost_real_workload.sh
+++ b/tests/nancy_run_localhost_real_workload.sh
@@ -15,7 +15,8 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Queries:[[:space:]]+1" ]]; then
+regex="Queries:[[:blank:]]*1"
+if [[ $output =~ $regex ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_dump.sh
+++ b/tests/nancy_run_localhost_simple_dump.sh
@@ -14,7 +14,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Queries duration:" ]]; then
+if [[ $output =~ "Sumarized query duration:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_dump.sh
+++ b/tests/nancy_run_localhost_simple_dump.sh
@@ -14,7 +14,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Sumarized query duration:" ]]; then
+if [[ $output =~ "Errors:            0:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_dump.sh
+++ b/tests/nancy_run_localhost_simple_dump.sh
@@ -14,7 +14,8 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Errors:            0:" ]]; then
+regex="Errors:[[:blank:]]*0"
+if [[ $output =~ $regex ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_dump.sh
+++ b/tests/nancy_run_localhost_simple_dump.sh
@@ -10,7 +10,7 @@ nancyRun="$parentDir/nancy_run.sh"
 
 output=$(
   $nancyRun --workload-custom-sql "file://$srcDir/custom.sql" \
-    --db-dump-path "file://$srcDir/test.dump.bz2" \
+    --db-dump "file://$srcDir/test.dump.bz2" \
     --tmp-path $srcDir/tmp 2>&1
 )
 

--- a/tests/nancy_run_localhost_simple_dump_with_index.sh
+++ b/tests/nancy_run_localhost_simple_dump_with_index.sh
@@ -16,7 +16,8 @@ output=$(
     --target-ddl-undo "drop index i_speedup;" 2>&1
 )
 
-if [[ $output =~ "Errors:            0:" ]]; then
+regex="Errors:[[:blank:]]*0"
+if [[ $output =~ $regex ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_dump_with_index.sh
+++ b/tests/nancy_run_localhost_simple_dump_with_index.sh
@@ -11,7 +11,7 @@ nancyRun="$parentDir/nancy_run.sh"
 output=$(
   $nancyRun --workload-custom-sql "file://$srcDir/custom.sql" \
     --tmp-path ${srcDir}/tmp \
-    --db-dump-path "file://$srcDir/test.dump.bz2" \
+    --db-dump "file://$srcDir/test.dump.bz2" \
     --target-ddl-do "create index i_speedup on t1 using btree(val);" \
     --target-ddl-undo "drop index i_speedup;" 2>&1
 )

--- a/tests/nancy_run_localhost_simple_dump_with_index.sh
+++ b/tests/nancy_run_localhost_simple_dump_with_index.sh
@@ -16,7 +16,7 @@ output=$(
     --target-ddl-undo "drop index i_speedup;" 2>&1
 )
 
-if [[ $output =~ "Sumarized query duration:" ]]; then
+if [[ $output =~ "Errors:            0:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_dump_with_index.sh
+++ b/tests/nancy_run_localhost_simple_dump_with_index.sh
@@ -16,7 +16,7 @@ output=$(
     --target-ddl-undo "drop index i_speedup;" 2>&1
 )
 
-if [[ $output =~ "Queries duration:" ]]; then
+if [[ $output =~ "Sumarized query duration:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_gz_dump.sh
+++ b/tests/nancy_run_localhost_simple_gz_dump.sh
@@ -14,7 +14,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Queries duration:" ]]; then
+if [[ $output =~ "Sumarized query duration:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_gz_dump.sh
+++ b/tests/nancy_run_localhost_simple_gz_dump.sh
@@ -10,7 +10,7 @@ nancyRun="$parentDir/nancy_run.sh"
 
 output=$(
   $nancyRun --workload-custom-sql "file://$srcDir/custom.sql" \
-    --db-dump-path "file://$srcDir/test.dump.gz" \
+    --db-dump "file://$srcDir/test.dump.gz" \
     --tmp-path $srcDir/tmp 2>&1
 )
 

--- a/tests/nancy_run_localhost_simple_gz_dump.sh
+++ b/tests/nancy_run_localhost_simple_gz_dump.sh
@@ -14,7 +14,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Sumarized query duration:" ]]; then
+if [[ $output =~ "Errors:            0:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_gz_dump.sh
+++ b/tests/nancy_run_localhost_simple_gz_dump.sh
@@ -14,7 +14,8 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Errors:            0:" ]]; then
+regex="Errors:[[:blank:]]*0"
+if [[ $output =~ $regex ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_sql_dump.sh
+++ b/tests/nancy_run_localhost_simple_sql_dump.sh
@@ -14,7 +14,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Queries duration:" ]]; then
+if [[ $output =~ "Sumarized query duration:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_sql_dump.sh
+++ b/tests/nancy_run_localhost_simple_sql_dump.sh
@@ -14,7 +14,7 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Sumarized query duration:" ]]; then
+if [[ $output =~ "Errors:            0:" ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_sql_dump.sh
+++ b/tests/nancy_run_localhost_simple_sql_dump.sh
@@ -14,7 +14,8 @@ output=$(
     --tmp-path $srcDir/tmp 2>&1
 )
 
-if [[ $output =~ "Errors:            0:" ]]; then
+regex="Errors:[[:blank:]]*0"
+if [[ $output =~ $regex ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"

--- a/tests/nancy_run_localhost_simple_sql_dump.sh
+++ b/tests/nancy_run_localhost_simple_sql_dump.sh
@@ -10,7 +10,7 @@ nancyRun="$parentDir/nancy_run.sh"
 
 output=$(
   $nancyRun --workload-custom-sql "file://$srcDir/custom.sql" \
-    --db-dump-path "file://$srcDir/test.dump.sql" \
+    --db-dump "file://$srcDir/test.dump.sql" \
     --tmp-path $srcDir/tmp 2>&1
 )
 

--- a/tests/nancy_run_options_both_dump_snapshot.sh
+++ b/tests/nancy_run_options_both_dump_snapshot.sh
@@ -7,7 +7,7 @@ read -r -d '' params <<PARAMS
   --s3cfg-path "/home/someuser/.s3cfg" \
   --workload-real "s3://somebucket/db.sql.30min.pgreplay" \
   --tmp-path tmp \
-  --db-dump-path "s3://somebucket/dump.sql.bz2" \
+  --db-dump "s3://somebucket/dump.sql.bz2" \
   --db-prepared-snapshot "s3://somebucket/snapshot"
 PARAMS
 

--- a/tests/nancy_run_options_ddl_do+_undo-.sh
+++ b/tests/nancy_run_options_ddl_do+_undo-.sh
@@ -7,7 +7,7 @@ read -r -d '' params <<PARAMS
   --s3cfg-path "/home/someuser/.s3cfg" \
   --workload-real "s3://somebucket/db.sql.30min.pgreplay" \
   --tmp-path tmp \
-  --db-dump-path "s3://somebucket/dump.sql.bz2" \
+  --db-dump "s3://somebucket/dump.sql.bz2" \
   --target-ddl-do "create\tindex\ti_zzz\ton\tsometable(col1);"
 PARAMS
 

--- a/tests/nancy_run_options_ddl_do-_undo+.sh
+++ b/tests/nancy_run_options_ddl_do-_undo+.sh
@@ -7,7 +7,7 @@ read -r -d '' params <<PARAMS
   --s3cfg-path "/home/someuser/.s3cfg" \
   --workload-real "s3://somebucket/db.sql.30min.pgreplay" \
   --tmp-path tmp \
-  --db-dump-path "s3://somebucket/dump.sql.bz2" \
+  --db-dump "s3://somebucket/dump.sql.bz2" \
   --target-ddl-undo "drop\tindex\ti_zzz;"
 PARAMS
 

--- a/tests/nancy_run_options_multi_workloads.sh
+++ b/tests/nancy_run_options_multi_workloads.sh
@@ -8,7 +8,7 @@ read -r -d '' params <<PARAMS
   --workload-real "s3://somebucket/db.sql.30min.pgreplay" \
   --workload-custom-sql "select\tnow();" \
   --tmp-path tmp \
-  --db-dump-path "s3://somebucket/dump.sql.bz2"
+  --db-dump "s3://somebucket/dump.sql.bz2"
 PARAMS
 
 output=$(${BASH_SOURCE%/*}/../nancy_run.sh $params 2>&1)

--- a/tests/nancy_run_options_no_dump_snapshot.sh
+++ b/tests/nancy_run_options_no_dump_snapshot.sh
@@ -11,7 +11,7 @@ PARAMS
 
 output=$(${BASH_SOURCE%/*}/../nancy_run.sh $params 2>&1)
 
-if [[ $output =~ "ERROR: Snapshot or dump not given." ]]; then
+if [[ $output =~ "ERROR: The object (database) is not defined." ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"


### PR DESCRIPTION
- `--db-dump-path` renamed to `--db-path`
- refactored the text of the Summary printed in terminal after a run
- some error messages changes
- for `nancy run`, first check `--db-***` options, and only then `--workload-***`