### PR TITLE
WIP: fixes of macOS; better work with docker machine, misc improvements

### DIFF
--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -577,7 +577,7 @@ if ([ "$RUN_ON" == "aws" ] && [ ! ${AWS_EC2_TYPE:0:2} == "i3" ] && \
       dumpFileSize=$(stat -c%s "$DB_DUMP_PATH")
     fi
     let dumpFileSize=dumpFileSize*$EBS_SIZE_MULTIPLIER
-    let minSize=300 * $KB * $KB * $KB
+    let minSize=300*$KB*$KB*$KB
     ebsSize=$minSize # 300 GB
     if [ "$dumpFileSize" -gt "$minSize" ]; then
         let ebsSize=$dumpFileSize

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -548,7 +548,7 @@ function checkParams() {
   if [ ! -z ${EBS_VOLUME_SIZE+x} ]; then
     re='^[0-9]+$'
     if ! [[ $EBS_VOLUME_SIZE =~ $re ]] ; then
-      err "ERROR: ebs-volume-size must be numeric integer value."
+      err "ERROR: ebs-volume-size must be integer."
       exit 1
     fi
   else

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -574,7 +574,7 @@ if ([ "$RUN_ON" == "aws" ] && [ ! ${AWS_EC2_TYPE:0:2} == "i3" ] && \
       dumpFileSize=${dumpFileSize// /}
       [ $DEBUG -eq 1 ] && msg "S3 file size: $dumpFileSize"
     else
-      dumpFileSize=$(stat -c%s "$DB_DUMP_PATH")
+      dumpFileSize=$(wc -c "$DB_DUMP_PATH" | awk '{print $1}')
     fi
     let dumpFileSize=dumpFileSize*$EBS_SIZE_MULTIPLIER
     let minSize=300*$KB*$KB*$KB

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -553,7 +553,7 @@ function checkParams() {
     fi
   else
     if [[ ! ${AWS_EC2_TYPE:0:2} == 'i3' ]]; then
-      err "WARNING: ebs-volume-size is not given, will be calculate on base of dump size."
+      err "WARNING: ebs-volume-size is not given, will be calculated based on the dump size."
     fi
   fi
 }
@@ -583,9 +583,9 @@ if ([ "$RUN_ON" == "aws" ] && [ ! ${AWS_EC2_TYPE:0:2} == "i3" ] && \
         let ebsSize=$dumpFileSize
         ebsSize=$(numfmt --to-unit=G $ebsSize)
         EBS_VOLUME_SIZE=$ebsSize
-        [ $DEBUG -eq 1 ] && msg "EBS volume size: $EBS_VOLUME_SIZE Gb"
+        [ $DEBUG -eq 1 ] && msg "EBS volume size: $EBS_VOLUME_SIZE GB"
     else
-      msg "EBS volume is not require."
+      msg "EBS volume is not required."
     fi
 fi
 

--- a/tests/nancy_run_ebs_disk_size_incorrect.sh
+++ b/tests/nancy_run_ebs_disk_size_incorrect.sh
@@ -7,7 +7,7 @@ output=$(${BASH_SOURCE%/*}/../nancy run \
   --tmp-path $srcDir/tmp \
   2>&1)
 
-if [[ $output =~ "WARNING: ebs-volume-size is not required for aws i3 aws instances and local execution." ]]; then
+if [[ $output =~ "ERROR: ebs-volume-size must be integer." ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"


### PR DESCRIPTION
Misc improvements:
 - fixes for macOS
 - default tmp path is `/tmp` 
 - `err` and `msg` functions
 - messages fixes
 - README.md improved (including examples)
 - Postgres 10 is now default
 - ...

TODO:
 - [ ] fix working with i3 instances
 - [ ] double-check all examples in README.md
 - [ ] fix "file://..." on macOS:

```
ERROR:  syntax error at or near "file"
LINE 1: file:///Users/nikolay/sample.dump.bz2
```

 - [ ] fix `stat -c%s FILENAME` on macos (use `stat -f%z in.sql` <s>OR do it inside container</s>):

```
stat: illegal option -- c
usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]
```

 - ...