### PR TITLE
Allow using * in textual CLI parameters 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .circleci/tmp
-./*.json
-./*.gz
+docker/tmp
+*.gz
+*.json

--- a/nancy
+++ b/nancy
@@ -8,43 +8,41 @@ case "$1" in
         echo -e "
 \033[1mDESCRIPTION\033[22m
 
-  The Nancy Command Line Interface is a unified way to manage
-  database experiments.
+  The Nancy Command Line Interface is a unified way to manage database
+  experiments.
 
-  Nancy is a member of Postgres.ai's Artificial DBA team
-  responsible for conducting experiments.
+  Nancy is a member of Postgres.ai's Artificial DBA team responsible for
+  conducting experiments.
 
 \033[1mSYNOPSYS\033[22m
 
-    nancy <command> [parameters]
+  nancy <command> [parameters]
 
 \033[1mAVAILABLE COMMANDS\033[22m
 
   * help
 
-  * prepare-database
+  * prepare-database (WIP)
 
   * prepare-workload
 
   * run
-" | less -RFX
-        exit 1;
-        ;;
-    * )
-        word="${1/-/_}"
-        if [ ! -f "${BASH_SOURCE%/*}/nancy_$word.sh" ]
-        then
-            >&2 echo "ERROR: Unknown command."
-            >&2 echo "Try 'nancy help'"
-            exit 1;
-        fi
-        cmd="${BASH_SOURCE%/*}/nancy_$word.sh"
-        shift;
-    ;;
+  " | less -RFX
+  exit 1;
+  ;;
+* )
+  word="${1/-/_}"
+  if [[ ! -f "${BASH_SOURCE%/*}/nancy_$word.sh" ]]; then
+    >&2 echo "ERROR: Unknown command: $word."
+    >&2 echo "Try 'nancy help'"
+    exit 1
+  fi
+  cmd="${BASH_SOURCE%/*}/nancy_$word.sh"
+  shift;
+  ;;
 esac
 
-while [ -n "$1" ]
-do
+while [ -n "$1" ]; do
   if [ "$1" == "--debug" ]; then
     DEBUG=1
   fi
@@ -56,6 +54,6 @@ do
   shift
 done
 
-[ "$DEBUG" -eq "1" ] &&  echo "CMD: $cmd"
+[[ "$DEBUG" -eq "1" ]] && echo "CMD: $cmd"
 
-eval $cmd
+eval "$cmd"

--- a/tests/nancy_run_localhost_wildcards.sh
+++ b/tests/nancy_run_localhost_wildcards.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+realpath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+src_dir=$(dirname $(dirname $(realpath "$0")))"/.circleci"
+
+output=$(
+  ${BASH_SOURCE%/*}/../nancy run \
+    --db-dump "create table t1 as select * from generate_series(1, 1000);" \
+    --workload-custom-sql "select count(*) from t1;" \
+    --tmp-path $src_dir/tmp 2>&1
+)
+
+regex="Errors:[[:blank:]]*0"
+if [[ $output =~ $regex ]]; then
+  echo -e "\e[36mOK\e[39m"
+else
+  >&2 echo -e "\e[31mFAILED\e[39m"
+  >&2 echo -e "Output: $output"
+  exit 1
+fi
+


### PR DESCRIPTION
Now this works:

```shell
nancy run \
  --db-dump "create table t1 as select * from generate_series(1, 1000);" \
  --workload-custom-sql "select count(*) from t1;"
```

Additionally:
 - fix gitignore to ignore .gz and .json
 - ignore tmp dir in ./docker
 - code style in `./nancy`