### PR TITLE
WIP: Series runs

### DIFF
--- a/.circleci/run.yml
+++ b/.circleci/run.yml
@@ -1,0 +1,13 @@
+run:
+  0:
+    delta_ddl_do: select now(); select now();
+    delta_ddl_undo: select now();
+#    delta_config: max_wal_size = 2048MB
+  1:
+#    delta_ddl_do: select now();
+#    delta_ddl_undo: select now();
+    delta_config: max_wal_size = 4092MB
+#  2:
+#    delta_ddl_do: select now();
+#    delta_ddl_undo: select now();
+#    delta_config: max_wal_size = 4092MB    

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -28,10 +28,6 @@ function _attach_pancake_drive() {
   docker-machine ssh $DOCKER_MACHINE "sudo df -h /dev/xvdc"
 }
 
-function _dettach_pancake_drive() {
-  dettachResult=$(aws --region=$AWS_REGION ec2 detach-volume --volume-id $DB_EBS_VOLUME_ID)
-}
-
 #######################################
 # Print a help
 # Globals:
@@ -1248,6 +1244,7 @@ elif [[ "$RUN_ON" == "aws" ]]; then
   CONTAINER_HASH=$( \
     docker `docker-machine config $DOCKER_MACHINE` run \
       --name="pg_nancy_${CURRENT_TS}" \
+      --privileged \
       -v /home/ubuntu:/machine_home \
       -v /home/storage:/storage \
       -v /home/basedump:/basedump \
@@ -1265,6 +1262,13 @@ MACHINE_HOME="/machine_home/nancy_${CONTAINER_HASH}"
 
 alias docker_exec='docker $DOCKER_CONFIG exec -i ${CONTAINER_HASH} '
 CPU_CNT=$(docker_exec bash -c "cat /proc/cpuinfo | grep processor | wc -l") # for execute in docker
+
+
+function _dettach_pancake_drive() {
+  docker_exec bash -c "umount /basedump"
+  docker-machine ssh $DOCKER_MACHINE sudo umount /home/basedump
+  dettachResult=$(aws --region=$AWS_REGION ec2 detach-volume --volume-id $DB_EBS_VOLUME_ID)
+}
 
 #######################################
 # Copy file to container

--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -1512,8 +1512,8 @@ function prepare_start_workload() {
   )
   if [[ "$run_number" -eq "1" ]]; then
     # save preparation log only before first run
-    docker_exec bash -c "mkdir $MACHINE_HOME/$ARTIFACTS_FILENAME"
-    docker_exec bash -c "gzip -c $logpath > $MACHINE_HOME/$ARTIFACTS_FILENAME/$ARTIFACTS_FILENAME.$run_number.prepare.log.gz"
+    docker_exec bash -c "mkdir -p $MACHINE_HOME/$ARTIFACTS_FILENAME"
+    docker_exec bash -c "gzip -c $logpath > $MACHINE_HOME/$ARTIFACTS_FILENAME/$ARTIFACTS_FILENAME.prepare.log.gz"
   fi
 
   # Clear statistics and log
@@ -1611,8 +1611,7 @@ function collect_results() {
   docker_exec bash -c "psql -U postgres $DB_NAME -b -c '\copy (select * from pg_stat_user_functions) to /$MACHINE_HOME/$ARTIFACTS_FILENAME/pg_stat_user_functions.$run_number.csv with csv;' $VERBOSE_OUTPUT_REDIRECT"
   docker_exec bash -c "psql -U postgres $DB_NAME -b -c '\copy (select * from pg_stat_xact_user_functions) to /$MACHINE_HOME/$ARTIFACTS_FILENAME/pg_stat_xact_user_functions.$run_number.csv with csv;' $VERBOSE_OUTPUT_REDIRECT"
 
-
-  docker_exec bash -c "gzip -c $logpath > $MACHINE_HOME/$ARTIFACTS_FILENAME/postgresql.workload.log.gz"
+  docker_exec bash -c "gzip -c $logpath > $MACHINE_HOME/$ARTIFACTS_FILENAME/postgresql.workload.$run_number.log.gz"
   docker_exec bash -c "cp /etc/postgresql/$PG_VERSION/main/postgresql.conf $MACHINE_HOME/$ARTIFACTS_FILENAME/postgresql.$run_number.conf"
   msg "Save artifacts..."
   if [[ $ARTIFACTS_DESTINATION =~ "s3://" ]]; then
@@ -1621,7 +1620,7 @@ function collect_results() {
     if [[ "$RUN_ON" == "localhost" ]]; then
       docker cp $CONTAINER_HASH:$MACHINE_HOME/$ARTIFACTS_FILENAME $ARTIFACTS_DESTINATION/
     elif [[ "$RUN_ON" == "aws" ]]; then
-      mkdir $ARTIFACTS_DESTINATION/$ARTIFACTS_FILENAME
+      mkdir -p $ARTIFACTS_DESTINATION/$ARTIFACTS_FILENAME
       docker-machine scp $DOCKER_MACHINE:/home/storage/$ARTIFACTS_FILENAME/* $ARTIFACTS_DESTINATION/$ARTIFACTS_FILENAME/
     else
       err "ASSERT: must not reach this point"


### PR DESCRIPTION
Добавлена опция --runs-config  с которой передается путь к yml файлу с описанием дельт для прогонов.
Формат файла 
```
run:
  0:
    delta_ddl_do: select now(); select now();
    delta_ddl_undo: select now();
#    delta_config: max_wal_size = 2048MB
  1:
#    delta_ddl_do: select now();
#    delta_ddl_undo: select now();
    delta_config: max_wal_size = 4092MB
#  2:
#    delta_ddl_do: select now();
#    delta_ddl_undo: select now();
#    delta_config: max_wal_size = 4092MB    
```
Пока поддерживает только однострочные значения.
В коде не зависимо от того переданы настройки через yml или отдельными опциями формируется массив с прогонами (в случае с опциями только с одним элементом).
Далее в цикле копируются данные на контейнер машину. В названиях всех файлов появляется индекс прогона. Для внутреннего использования от 0 до N-1, для артифактов 1- N.

Перед первым прогоном разворачивается база (из бэкапа или дампа) , для последующих либо rsync из бэкапа или повторное разворачивание дампа. 

Так же добавлена опция ~--backup-volume-id~ --db-ebs-volume-id для передачи id диска с бэкапом.
