### PR TITLE
Reset all stats, including related to bgwriter and archiver

### DIFF
--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -1419,7 +1419,9 @@ function prepare_start_workload() {
   docker_exec bash -c "gzip -c $logpath > $MACHINE_HOME/$ARTIFACTS_FILENAME/postgresql.prepare.log.gz"
 
   msg "Reset pg_stat_*** and Postgres log"
-  docker_exec psql -U postgres $DB_NAME -c 'select pg_stat_reset(), pg_stat_statements_reset();' >/dev/null
+  >/dev/null docker_exec psql -U postgres $DB_NAME -f - <<EOF
+    select pg_stat_reset(), pg_stat_statements_reset(), pg_stat_reset_shared('archiver'), pg_stat_reset_shared('bgwriter');
+EOF
   docker_exec bash -c "echo '' > /var/log/postgresql/postgresql-$PG_VERSION-main.log"
 }
 


### PR DESCRIPTION
Reset some cluster-wide statistics counters to zero, depending on the argument (requires superuser privileges by default, but EXECUTE for this function can be granted to others). Calling pg_stat_reset_shared('bgwriter') will zero all the counters shown in the pg_stat_bgwriter view. Calling pg_stat_reset_shared('archiver') will zero all the counters shown in the pg_stat_archiver view.

See https://www.postgresql.org/docs/current/static/monitoring-stats.html