### PR TITLE
Add system_info.txt artifact

### DIFF
--- a/tests/nancy_run_localhost_simple_dump.sh
+++ b/tests/nancy_run_localhost_simple_dump.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+test_passed=true
 
 realpath() {
   [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
@@ -14,7 +15,18 @@ output=$(
 )
 
 regex="Errors:[[:blank:]]*0"
-if [[ $output =~ $regex ]]; then
+if [[ ! $output =~ $regex ]]; then
+  test_passed=false
+fi
+
+artifacts_location=$(
+  echo "$output" | grep "Artifacts location:" | awk -F': ' '{print $2}'
+)
+if [[ ! $(grep Linux "$artifacts_location/system_info.txt") =~ ^Linux ]]; then
+  test_passed=false
+fi
+
+if [[ $test_passed ]]; then
   echo -e "\e[36mOK\e[39m"
 else
   >&2 echo -e "\e[31mFAILED\e[39m"


### PR DESCRIPTION
   Get more system info and put it to system_info.txt
   artifact. Includes:
     - CPU info
     - Memory (free)
     - disks
     - Linux kerner version
     - glibc version
     - bash version

Output example:
```
CPU_CNT: 8, RAM_MB: 16380.0, DISK_ROTATIONAL: false

=== System ===
Linux 6bf3cf5b4c9c 3.16.0-4-amd64 #1 SMP Debian 3.16.43-2+deb8u1 (2017-06-18) x86_64 x86_64 x86_64 GNU/Linux

Distributor ID: Ubuntu
Description:    Ubuntu 16.04.5 LTS
Release:        16.04
Codename:       xenial

=== glibc ===
ldd (Ubuntu GLIBC 2.23-0ubuntu10) 2.23

=== bash ===
GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)

=== CPU ===
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                8
On-line CPU(s) list:   0-7
Thread(s) per core:    2
Core(s) per socket:    4
Socket(s):             1
NUMA node(s):          1
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 42
Model name:            Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz
Stepping:              7
CPU MHz:               3507.046
CPU max MHz:           3800.0000
CPU min MHz:           1600.0000
BogoMIPS:              6823.29
Virtualization:        VT-x
Hypervisor vendor:     vertical
Virtualization type:   full
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              8192K
NUMA node0 CPU(s):     0-7
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid

=== Memory ===
              total        used        free      shared  buff/cache   available
Mem:       16380132     1466796      980600      765948    13932736    13753808
Swap:       8387568     3182536     5205032

=== Storage ===
Filesystem     Type   Size  Used Avail Use% Mounted on
none           aufs  1016G  435G  531G  46% /
tmpfs          tmpfs   64M     0   64M   0% /dev
tmpfs          tmpfs  7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/md2       ext4  1016G  435G  531G  46% /machine_home
shm            tmpfs   64M  8.0K   64M   1% /dev/shm
tmpfs          tmpfs  7.9G     0  7.9G   0% /sys/firmware

NAME    MAJ:MIN RM  SIZE RO TYPE  MOUNTPOINT
sda       8:0    0  2.7T  0 disk
|-sda1    8:1    0    8G  0 part
| `-md0   9:0    0    8G  0 raid1 [SWAP]
|-sda2    8:2    0  512M  0 part
| `-md1   9:1    0  512M  0 raid1
|-sda3    8:3    0    1T  0 part
| `-md2   9:2    0 1024G  0 raid1 /etc/hosts
|-sda4    8:4    0  1.7T  0 part
| `-md3   9:3    0  1.7T  0 raid1
`-sda5    8:5    0    1M  0 part
sdb       8:16   0  2.7T  0 disk
|-sdb1    8:17   0    8G  0 part
| `-md0   9:0    0    8G  0 raid1 [SWAP]
|-sdb2    8:18   0  512M  0 part
| `-md1   9:1    0  512M  0 raid1
|-sdb3    8:19   0    1T  0 part
| `-md2   9:2    0 1024G  0 raid1 /etc/hosts
|-sdb4    8:20   0  1.7T  0 part
| `-md3   9:3    0  1.7T  0 raid1
`-sdb5    8:21   0    1M  0 part
loop0     7:0    0        0 loop
loop1     7:1    0        0 loop
loop2     7:2    0        0 loop
loop3     7:3    0        0 loop
loop4     7:4    0        0 loop
loop5     7:5    0        0 loop
loop6     7:6    0        0 loop
loop7     7:7    0        0 loop
```